### PR TITLE
using .format was stripping out single quotes.

### DIFF
--- a/roles/create-openshift-resources/filter_plugins/general_filters.py
+++ b/roles/create-openshift-resources/filter_plugins/general_filters.py
@@ -15,7 +15,7 @@ def create_param_string(key_value_pairs):
     pairs = []
     string = ""
     for key in key_value_pairs:
-        pair = "\"{}={}\"".format(key, key_value_pairs[key])
+        pair = "%s='%s'" % (key, key_value_pairs[key])
         pairs.append(pair)
     for i, pair in enumerate(pairs):
         string += " -p {}".format(pair)
@@ -26,7 +26,7 @@ def create_env_string(key_value_pairs):
     pairs = []
     string = ""
     for key in key_value_pairs:
-        pair = "\"{}={}\"".format(key, key_value_pairs[key])
+        pair = "%s='%s'" % (key, key_value_pairs[key])
         pairs.append(pair)
     for i, pair in enumerate(pairs):
         string += " -e {}".format(pair)


### PR DESCRIPTION
These are required for setting environment variables with special
characters.

#### What does this PR do?
The .format method seemed to strip out the single quotes

#### Which tests illustrate how this code works?
A full stack run continues to work

#### Is there a relevant Issue open for this?
This is required for Sonar's LDAP integration